### PR TITLE
new configuration `overtype.showInStatusBar` and status bar as toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable and interesting changes will go in this file whenever a new release goes
 ## TO BE ANNOUNCED
 
 - New configuration `overtype.showInStatusBar`, to allow hiding the current state in the status bar [#4](https://github.com/DrMerfy/vscode-overtype/issues/4).
+- The item in the status bar can now be clicked to toggle the insert mode [#3](https://github.com/DrMerfy/vscode-overtype/issues/3).
 
 ## 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Notable and interesting changes will go in this file whenever a new release goes out. Boring changes will probably go in here too. Really, all changes are welcome.
 
+## TO BE ANNOUNCED
+
+- New configuration `overtype.showInStatusBar`, to allow hiding the current state in the status bar [#4](https://github.com/DrMerfy/vscode-overtype/issues/4).
+
 ## 0.3.1
 
 - open-vsx ready, now also found at https://open-vsx.org/extension/DrMerfy/overtype

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Without further ado...
 
 > When in overtype mode, uses overtype behavior when pasting text.
 
-### Abbreviated indicators
+### Abbreviated indicators (or none)
 
 Horizontal screen space at a premium? Have too many things in your status bar already? Turned your monitor sideways because somebody told you it would increase your productivity by at least 23%? Don't worry, we've got just the setting for you!
 
@@ -67,7 +67,13 @@ Horizontal screen space at a premium? Have too many things in your status bar al
 "overtype.abbreviatedStatus": true
 ```
 
-> Shows an abbreviated overtype status (`INS`/`OVR`) in the status line.
+> Shows an abbreviated overtype status (`INS`/`OVR`) in the status bar.
+
+```json
+"overtype.showInStatusBar": false
+```
+
+> Disable showing the overtype status in the status bar.
 
 ### Overtype cursor style
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
                 "overtype.abbreviatedStatus": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Shows an abbreviated overtype status (INS/OVR) in the status line."
+                    "description": "Shows an abbreviated overtype status (INS/OVR) in the status bar."
                 },
                 "overtype.paste": {
                     "type": "boolean",
@@ -55,6 +55,11 @@
                     "type": "string",
                     "default": "block",
                     "description": "Sets the overtype cursor style."
+                },
+                "overtype.showInStatusBar": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows the current overtype mode in the status bar."
                 }
             }
         },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -20,6 +20,7 @@ function loadConfiguration() {
 
     return {
         abbreviatedStatus: overtypeConfiguration.get<boolean>("abbreviatedStatus"),
+        showInStatusBar: overtypeConfiguration.get<boolean>("showInStatusBar"),
         paste: overtypeConfiguration.get<boolean>("paste"),
         perEditor: overtypeConfiguration.get<boolean>("perEditor") ? true : false,
 
@@ -41,7 +42,8 @@ export function reloadConfiguration() {
     const newConfiguration = loadConfiguration();
 
     // bail out if nothing changed
-    if (configuration.abbreviatedStatus === newConfiguration.abbreviatedStatus &&
+    if (configuration.showInStatusBar === newConfiguration.showInStatusBar &&
+        configuration.abbreviatedStatus === newConfiguration.abbreviatedStatus &&
         configuration.paste === newConfiguration.paste &&
         configuration.perEditor === newConfiguration.perEditor &&
         configuration.defaultCursorStyle === newConfiguration.defaultCursorStyle &&
@@ -49,6 +51,7 @@ export function reloadConfiguration() {
         return false;
     }
 
+    configuration.showInStatusBar = newConfiguration.showInStatusBar;
     configuration.abbreviatedStatus = newConfiguration.abbreviatedStatus;
     configuration.paste = newConfiguration.paste;
     configuration.perEditor = newConfiguration.perEditor;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,19 +61,29 @@ function toggleCommand() {
 
 function onDidChangeConfiguration() {
     const previousPerEditor = configuration.perEditor;
+    const previousShowInStatusBar = configuration.showInStatusBar;
+
     const updated = reloadConfiguration();
+    if (!updated) { return; }
+
+    // post create / destroy when changed
+    if (configuration.showInStatusBar !== previousShowInStatusBar) {
+        if (configuration.showInStatusBar) {
+            createStatusBarItem();
+        } else {
+            destroyStatusBarItem();
+        }
+    }
 
     // update state if the per-editor/global configuration option changes
-    if (updated && configuration.perEditor !== previousPerEditor) {
+    if (configuration.perEditor !== previousPerEditor) {
 
         const textEditor = vscode.window.activeTextEditor;
         const mode = textEditor != null ? getMode(textEditor) : null;
         resetModes(mode, configuration.perEditor);
     }
 
-    if (updated) {
-        activeTextEditorChanged();
-    }
+    activeTextEditorChanged();
 }
 
 function shouldPerformOvertype() {

--- a/src/statusBarItem.ts
+++ b/src/statusBarItem.ts
@@ -8,6 +8,7 @@ export function createStatusBarItem() {
     if (statusBarItem != null) { return statusBarItem; }
 
     statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
+    statusBarItem.command = "overtype.toggle";
     statusBarItem.show();
 
     updateStatusBarItem(null);


### PR DESCRIPTION
to hide the current state in the status bar, fixes #4 and to make the status bar item a toggle, fixing #3

I'm quite confident about this change, tested via debugging, but still would like to have a review because that is actually my very first real TypeScript change in any vscode extension.

Additional I'm not as confident with git as I'm with svn which may is visible with the 4 instead of 2 commits. @DrMerfy Can you please drop a note how to force-push this "magically" into two commits (that's the reason for the draft state, I consider the changes "working")?