### PR TITLE
freely adjustable label texts for status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Notable and interesting changes will go in this file whenever a new release goes
 
 ## TO BE ANNOUNCED
 
-- New configuration `overtype.showInStatusBar`, to allow hiding the current state in the status bar [#4](https://github.com/DrMerfy/vscode-overtype/issues/4).
+- Replaced configuration `overtype.abbreviatedStatus` by freely adjustable texts `overtype.labelInsertMode` and `overtype.labelOvertypeMode` [#9](https://github.com/DrMerfy/vscode-overtype/issues/9),
+  which allows free abbreviation, localization and also allows hiding the current state in the status bar [#4](https://github.com/DrMerfy/vscode-overtype/issues/4).
 - The item in the status bar can now be clicked to toggle the insert mode [#3](https://github.com/DrMerfy/vscode-overtype/issues/3).
 
 ## 0.3.1

--- a/README.md
+++ b/README.md
@@ -59,21 +59,26 @@ Without further ado...
 
 > When in overtype mode, uses overtype behavior when pasting text.
 
-### Abbreviated indicators (or none)
+### Adjusted indicators in status bar (abbreviated, localized or none)
 
-Horizontal screen space at a premium? Have too many things in your status bar already? Turned your monitor sideways because somebody told you it would increase your productivity by at least 23%? Don't worry, we've got just the setting for you!
-
-```json
-"overtype.abbreviatedStatus": true
-```
-
-> Shows an abbreviated overtype status (`INS`/`OVR`) in the status bar.
+Horizontal screen space at a premium? Have too many things in your status bar already?
+Turned your monitor sideways because somebody told you it would increase your productivity by at least 23%?
+Or simply want to match the language to the general UI?
+Don't worry, we've got just the setting for you!
 
 ```json
-"overtype.showInStatusBar": false
+"overtype.labelInsertMode": "",
+"overtype.labelOvertypeMode": "Ovr"
 ```
 
-> Disable showing the overtype status in the status bar.
+> Shows an abbreviated overtype status (`Ovr`) in the status bar if active, and nothing for the "normal" insert mode.
+
+```json
+"overtype.labelInsertMode": "",
+"overtype.labelOvertypeMode": ""
+```
+
+> Disable showing the overtype status in the status bar completely.
 
 ### Overtype cursor style
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "overtype",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "displayName": "Overtype",
     "description": "Provides insert/overtype mode.",
     "publisher": "DrMerfy",
@@ -36,11 +36,6 @@
             "type": "object",
             "title": "Overtype configuration",
             "properties": {
-                "overtype.abbreviatedStatus": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Shows an abbreviated overtype status (INS/OVR) in the status bar."
-                },
                 "overtype.paste": {
                     "type": "boolean",
                     "default": false,
@@ -56,10 +51,15 @@
                     "default": "block",
                     "description": "Sets the overtype cursor style."
                 },
-                "overtype.showInStatusBar": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Shows the current overtype mode in the status bar."
+                "overtype.labelInsertMode": {
+                    "type": "string",
+                    "default": "Insert",
+                    "description": "Label text in the status bar shown during Insert Mode, may be empty to hide the status."
+                },
+                "overtype.labelOvertypeMode": {
+                    "type": "string",
+                    "default": "Overtype",
+                    "description": "Label text in the status bar shown during Overtype Mode, may be empty."
                 }
             }
         },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,10 +19,11 @@ function loadConfiguration() {
     const editorConfiguration = vscode.workspace.getConfiguration("editor");
 
     return {
-        abbreviatedStatus: overtypeConfiguration.get<boolean>("abbreviatedStatus"),
-        showInStatusBar: overtypeConfiguration.get<boolean>("showInStatusBar"),
         paste: overtypeConfiguration.get<boolean>("paste"),
         perEditor: overtypeConfiguration.get<boolean>("perEditor") ? true : false,
+
+        labelInsertMode: overtypeConfiguration.get<String>("labelInsertMode"),
+        labelOvertypeMode: overtypeConfiguration.get<String>("labelOvertypeMode"),
 
         // tslint:disable-next-line:object-literal-sort-keys
         defaultCursorStyle: (() => {
@@ -42,8 +43,8 @@ export function reloadConfiguration() {
     const newConfiguration = loadConfiguration();
 
     // bail out if nothing changed
-    if (configuration.showInStatusBar === newConfiguration.showInStatusBar &&
-        configuration.abbreviatedStatus === newConfiguration.abbreviatedStatus &&
+    if (configuration.labelInsertMode === newConfiguration.labelInsertMode &&
+        configuration.labelOvertypeMode === newConfiguration.labelOvertypeMode &&
         configuration.paste === newConfiguration.paste &&
         configuration.perEditor === newConfiguration.perEditor &&
         configuration.defaultCursorStyle === newConfiguration.defaultCursorStyle &&
@@ -51,8 +52,8 @@ export function reloadConfiguration() {
         return false;
     }
 
-    configuration.showInStatusBar = newConfiguration.showInStatusBar;
-    configuration.abbreviatedStatus = newConfiguration.abbreviatedStatus;
+    configuration.labelInsertMode = newConfiguration.labelInsertMode;
+    configuration.labelOvertypeMode = newConfiguration.labelOvertypeMode;
     configuration.paste = newConfiguration.paste;
     configuration.perEditor = newConfiguration.perEditor;
     configuration.defaultCursorStyle = newConfiguration.defaultCursorStyle;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,16 +59,26 @@ function toggleCommand() {
     activeTextEditorChanged(textEditor);
 }
 
+function getShowInStatusBar(): boolean {
+    if (configuration.labelInsertMode === ""
+     && configuration.labelOvertypeMode === "") {
+        return true;
+     }
+     return false;
+}
+
 function onDidChangeConfiguration() {
     const previousPerEditor = configuration.perEditor;
-    const previousShowInStatusBar = configuration.showInStatusBar;
+    const previousShowInStatusBar = getShowInStatusBar();
 
     const updated = reloadConfiguration();
     if (!updated) { return; }
 
+    const showInStatusBar = getShowInStatusBar();
+
     // post create / destroy when changed
-    if (configuration.showInStatusBar !== previousShowInStatusBar) {
-        if (configuration.showInStatusBar) {
+    if (showInStatusBar !== previousShowInStatusBar) {
+        if (showInStatusBar) {
             createStatusBarItem();
         } else {
             destroyStatusBarItem();

--- a/src/statusBarItem.ts
+++ b/src/statusBarItem.ts
@@ -31,15 +31,26 @@ export function updateStatusBarItem(overtype: boolean | null) {
         statusBarItem.tooltip = "";
 
         statusBarItem.hide();
-    } else if (overtype) {
-        statusBarItem.text = configuration.abbreviatedStatus ? "OVR" : "Overtype";
-        statusBarItem.tooltip = "Overtype Mode";
-
-        statusBarItem.show();
-    } else {
-        statusBarItem.text = configuration.abbreviatedStatus ? "INS" : "Insert";
-        statusBarItem.tooltip = "Insert Mode";
-
-        statusBarItem.show();
+        return;
     }
+    
+    let sbiText;
+
+    if (overtype) {
+        sbiText = configuration.labelOvertypeMode;
+        statusBarItem.tooltip = "Overtype Mode, click to change to Insert Mode";
+    } else {
+        sbiText = configuration.labelInsertMode;
+        statusBarItem.tooltip = "Insert Mode, click to change to Overtype Mode";
+    }
+    if (sbiText === undefined || sbiText == null) sbiText = "";
+
+    // preparation for https://github.com/DrMerfy/vscode-overtype/issues/2
+    // if (configuration.showCapsLockState && capsLockOn) {
+    //     statusBarItem.text = sbiText.toUpperCase();
+    // } else {
+        statusBarItem.text = sbiText.toString();
+    // }
+
+    statusBarItem.show();
 }


### PR DESCRIPTION
fixes #9 and #4

Note: I've increased the version number because of the "breaking" change to remove `overtype.abbreviatedStatus`