### PR TITLE
Avail isToggledOn context property for use w/ "when"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable and interesting changes will go in this file whenever a new release goes out. Boring changes will probably go in here too. Really, all changes are welcome.
 
+## 0.4.8
+- Added `overtype.isToggledOn` context property, which can be used with `when` in user-defined `keybindings.json`
+
 ## 0.4.7
 - Downgraded to support vscode engine 1.55.0
 - Added ESlint inplace of TSlint

--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ e.g.
 
 > Sets the overtype cursor style.
 
+### Keybindings based on current overtype mode
+
+You can add additional keybindings conditionally based on the current overtype mode.
+
+e.g., to bind `Esc` *only* for *turning off* overtype, in `keybindings.json`,
+
+```json
+{
+  "key": "escape",
+  "command": "overtype.toggle",
+  "when": "editorTextFocus && overtype.isToggledOn"
+}
+```
+
 ## Contributing
 
 How can you contribute?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "overtype",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "overtype",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "displayName": "Overtype",
     "description": "Provides insert/overtype mode.",
     "publisher": "DrMerfy",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,9 +38,11 @@ const activeTextEditorChanged = (textEditor?: vscode.TextEditor) => {
 
     if (textEditor == null) {
         updateStatusBarItem(null);
+        updateWhenContext(null);
     } else {
         const mode = getMode(textEditor);
         updateStatusBarItem(mode);
+        updateWhenContext(mode);
 
         // if in overtype mode, set the cursor to secondary style; otherwise, reset to default
         textEditor.options.cursorStyle = mode
@@ -48,6 +50,10 @@ const activeTextEditorChanged = (textEditor?: vscode.TextEditor) => {
             : configuration.defaultCursorStyle;
     }
 }
+
+const updateWhenContext = (overtype: boolean | null) => {
+    vscode.commands.executeCommand('setContext', 'overtype.isToggledOn', overtype);
+};
 
 const toggleCommand = () => {
     const textEditor = vscode.window.activeTextEditor;


### PR DESCRIPTION
It'd be nice to be able to configure a user-defined keybinding that is only in effect when overtype is enabled. Visual Studio Code has `when` in `keybindings.json` for this kind of thing, but the extension doesn't currently set any context properties.

This adds `overtype.isToggledOn` as a context property, along with an example.

I'm updating the property alongside `updateStatusBarItem()` in `activeTextEditorChanged()`, which in addition to being aware of the `activeTextEditor` and `configuration.perEditor`, is called from pretty much everywhere else (on extension activation, on toggle, on configuration change), so I think it should stay in-sync with everything.