### PR TITLE
Change the status bar indicator color when the overtype mode is turned onFeat/highlight statusitem

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -51,6 +51,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "juarezr",
+      "name": "Juarez Rudsatz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/576780?v=4",
+      "profile": "https://github.com/juarezr",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Thanks goes to these wonderful people:
       <td align="center" valign="top" width="14.28%"><a href="https://przybyl.io"><img src="https://avatars.githubusercontent.com/u/2318282?v=4?s=100" width="100px;" alt="Mateusz Przybył"/><br /><sub><b>Mateusz Przybył</b></sub></a><br /><a href="https://github.com/DrMerfy/vscode-overtype/commits?author=MrSimbax" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/DrMerfy"><img src="https://avatars.githubusercontent.com/u/21154979?v=4?s=100" width="100px;" alt="George Melissourgos"/><br /><sub><b>George Melissourgos</b></sub></a><br /><a href="#projectManagement-DrMerfy" title="Project Management">📆</a> <a href="https://github.com/DrMerfy/vscode-overtype/commits?author=DrMerfy" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/corpulentcoffee"><img src="https://avatars.githubusercontent.com/u/3958448?v=4?s=100" width="100px;" alt="Dave Shifflett"/><br /><sub><b>Dave Shifflett</b></sub></a><br /><a href="https://github.com/DrMerfy/vscode-overtype/commits?author=corpulentcoffee" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/juarezr"><img src="https://avatars.githubusercontent.com/u/576780?v=4?s=100" width="100px;" alt="Juarez Rudsatz"/><br /><sub><b>Juarez Rudsatz</b></sub></a><br /><a href="https://github.com/DrMerfy/vscode-overtype/commits?author=juarezr" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/src/statusBarItem.ts
+++ b/src/statusBarItem.ts
@@ -39,9 +39,13 @@ export const updateStatusBarItem = (overtype: boolean | null) => {
     if (overtype) {
         sbiText = configuration.labelOvertypeMode;
         statusBarItem.tooltip = "Overtype Mode, click to change to Insert Mode";
+        statusBarItem.color = new vscode.ThemeColor('statusBarItem.warningForeground');
+        statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
     } else {
         sbiText = configuration.labelInsertMode;
         statusBarItem.tooltip = "Insert Mode, click to change to Overtype Mode";
+        statusBarItem.color = new vscode.ThemeColor('statusBarItem.foreground');
+        statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.background');
     }
     if (sbiText === undefined || sbiText == null) sbiText = "";
 


### PR DESCRIPTION
## New Feature

- Change the status bar indicator color/appearance when the overtype mode is turned on
- Fixes #44
- Using [statusBarItem.warningBackground and statusBarItem.warningBackground](https://code.visualstudio.com/api/references/theme-color#status-bar-colors) as highlight color.